### PR TITLE
Add alignment with meta and helpers

### DIFF
--- a/src/components/ExampleTable.tsx
+++ b/src/components/ExampleTable.tsx
@@ -1,4 +1,5 @@
-import { Opportunity, createOpportunity, times } from "../utils";
+import { getCellAlignProps } from "../features/align";
+import { Opportunity, createOpportunity, mergeProps, times } from "../utils";
 import {
   createColumnHelper,
   flexRender,
@@ -13,8 +14,18 @@ const columnHelper = createColumnHelper<Opportunity>();
 const columns = [
   columnHelper.accessor("name", {}),
   columnHelper.accessor("accountId", {}),
-  columnHelper.accessor("amount", {}),
-  columnHelper.accessor("aRR", {}),
+  columnHelper.accessor("amount", {
+    meta: { align: "right" },
+  }),
+  columnHelper.accessor("aRR", {
+    meta: { align: "right" },
+  }),
+  columnHelper.accessor("isClosed", {
+    meta: { align: "center" },
+  }),
+  columnHelper.accessor("isWon", {
+    meta: { align: "center" },
+  }),
 ];
 
 export const ExampleTable = () => {
@@ -29,29 +40,43 @@ export const ExampleTable = () => {
       <thead>
         {table.getHeaderGroups().map((headerGroup) => (
           <tr key={headerGroup.id}>
-            {headerGroup.headers.map((header) => (
-              <th
-                key={header.id}
-                className="border-l-2 p-2"
-                style={{ width: header.getSize() }}
-              >
-                {flexRender(
-                  header.column.columnDef.header,
-                  header.getContext()
-                )}
-              </th>
-            ))}
+            {headerGroup.headers.map((header) => {
+              const props = mergeProps(
+                {
+                  className: "border-l-2 p-2",
+                  style: { width: header.getSize() },
+                },
+                getCellAlignProps(header)
+              );
+              return (
+                <th key={header.id} {...props}>
+                  {flexRender(
+                    header.column.columnDef.header,
+                    header.getContext()
+                  )}
+                </th>
+              );
+            })}
           </tr>
         ))}
       </thead>
       <tbody>
         {table.getRowModel().rows.map((row) => (
           <tr key={row.id} className="border-y-2">
-            {row.getVisibleCells().map((cell) => (
-              <td key={cell.id} className="border-l-2 px-2 py-1">
-                {flexRender(cell.column.columnDef.cell, cell.getContext())}
-              </td>
-            ))}
+            {row.getVisibleCells().map((cell) => {
+              const props = mergeProps(
+                {
+                  key: cell.id,
+                  className: "border-l-2 px-2 py-1",
+                },
+                getCellAlignProps(cell)
+              );
+              return (
+                <td key={cell.id} {...props}>
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </td>
+              );
+            })}
           </tr>
         ))}
       </tbody>

--- a/src/features/align.ts
+++ b/src/features/align.ts
@@ -1,0 +1,28 @@
+import { Cell, Header, RowData } from "@tanstack/react-table";
+
+export interface AlignColumnDefExtensions {
+  align?: "left" | "center" | "right";
+}
+
+const getCellAlignClassName = (align: AlignColumnDefExtensions["align"]) => {
+  switch (align) {
+    case "left":
+      return "text-left";
+    case "center":
+      return "text-center";
+    case "right":
+      return "text-right";
+    default:
+      return "";
+  }
+};
+
+export const getCellAlignProps = <TData extends RowData, TValue>({
+  column,
+}: Cell<TData, TValue> | Header<TData, TValue>) => {
+  if (!column.columnDef.meta?.align) return {};
+
+  return {
+    className: getCellAlignClassName(column.columnDef.meta.align),
+  };
+};

--- a/src/types/tanstack-react-table.ts
+++ b/src/types/tanstack-react-table.ts
@@ -1,0 +1,8 @@
+import { RowData } from "@tanstack/react-table";
+import "@tanstack/table-core";
+import { AlignColumnDefExtensions } from "../features/align";
+
+declare module "@tanstack/table-core" {
+  export interface ColumnMeta<TData extends RowData, TValue>
+    extends AlignColumnDefExtensions {}
+}


### PR DESCRIPTION
I feel like this is how Tanner wants it done.

- Does not mess with core row models
- Performs all the extra stuff in user land
- Uses column `meta` for extensions

<img width="960" alt="CleanShot 2023-08-29 at 15 44 22@2x" src="https://github.com/ccblaisdell/table-2-exploration-2/assets/34119/1c47ff22-9cd7-4c6e-bd7b-107b038eeb4c">

