### PR TITLE
With custom rowModel fn

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -15,4 +15,5 @@ module.exports = {
       { allowConstantExport: true },
     ],
   },
+  '@typescript-eslint/no-explicit-any': 0,
 }

--- a/src/components/ExampleTable.tsx
+++ b/src/components/ExampleTable.tsx
@@ -1,10 +1,10 @@
-import { Opportunity, createOpportunity, times } from "../utils";
+import { Opportunity, createOpportunity, mergeProps, times } from "../utils";
 import {
   createColumnHelper,
   flexRender,
-  getCoreRowModel,
   useReactTable,
 } from "@tanstack/react-table";
+import { getAlignmentRowModel } from "../utils/getAlignmentRowModel";
 
 const data = times(100, createOpportunity);
 
@@ -13,15 +13,17 @@ const columnHelper = createColumnHelper<Opportunity>();
 const columns = [
   columnHelper.accessor("name", {}),
   columnHelper.accessor("accountId", {}),
-  columnHelper.accessor("amount", {}),
-  columnHelper.accessor("aRR", {}),
+  columnHelper.accessor("amount", { meta: { align: "right" } }),
+  columnHelper.accessor("isClosed", { meta: { align: "center" } }),
+  columnHelper.accessor("isWon", { meta: { align: "center" } }),
+  columnHelper.accessor("aRR", { meta: { align: "right" } }),
 ];
 
 export const ExampleTable = () => {
   const table = useReactTable({
     columns,
     data,
-    getCoreRowModel: getCoreRowModel(),
+    getCoreRowModel: getAlignmentRowModel(),
   });
 
   return (
@@ -29,29 +31,42 @@ export const ExampleTable = () => {
       <thead>
         {table.getHeaderGroups().map((headerGroup) => (
           <tr key={headerGroup.id}>
-            {headerGroup.headers.map((header) => (
-              <th
-                key={header.id}
-                className="border-l-2 p-2"
-                style={{ width: header.getSize() }}
-              >
-                {flexRender(
-                  header.column.columnDef.header,
-                  header.getContext()
-                )}
-              </th>
-            ))}
+            {headerGroup.headers.map((header) => {
+              const props = mergeProps(
+                {
+                  className: "border-l-2 px-2 py-1",
+                  style: { width: header.getSize() },
+                },
+                header.getAlignmentProps?.()
+              );
+
+              return (
+                <th key={header.id} {...props}>
+                  {flexRender(
+                    header.column.columnDef.header,
+                    header.getContext()
+                  )}
+                </th>
+              );
+            })}
           </tr>
         ))}
       </thead>
       <tbody>
         {table.getRowModel().rows.map((row) => (
           <tr key={row.id} className="border-y-2">
-            {row.getVisibleCells().map((cell) => (
-              <td key={cell.id} className="border-l-2 px-2 py-1">
-                {flexRender(cell.column.columnDef.cell, cell.getContext())}
-              </td>
-            ))}
+            {row.getVisibleCells().map((cell) => {
+              const props = mergeProps(
+                { className: "border-l-2 px-2 py-1" },
+                cell.getAlignmentProps?.()
+              );
+
+              return (
+                <td key={cell.id} {...props}>
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </td>
+              );
+            })}
           </tr>
         ))}
       </tbody>

--- a/src/features/Alignment.ts
+++ b/src/features/Alignment.ts
@@ -1,0 +1,13 @@
+import { HTMLAttributes } from "react";
+
+export interface AlignmentColumnDefExtensions {
+  align?: "left" | "center" | "right";
+}
+
+export interface AlignmentCell {
+  getAlignmentProps?: () => HTMLAttributes<HTMLElement>;
+}
+
+export interface AlignmentHeader {
+  getAlignmentProps?: () => HTMLAttributes<HTMLElement>;
+}

--- a/src/types/react-table.d.ts
+++ b/src/types/react-table.d.ts
@@ -1,0 +1,13 @@
+import {
+  AlignmentCell,
+  AlignmentHeader,
+  AlignmentColumnDefExtensions,
+} from "../features/Alignment";
+
+declare module "@tanstack/table-core" {
+  export interface ColumnMeta extends AlignmentColumnDefExtensions {}
+
+  export interface Header extends AlignmentHeader {}
+
+  export interface Cell extends AlignmentCell {}
+}

--- a/src/utils/getAlignmentRowModel.ts
+++ b/src/utils/getAlignmentRowModel.ts
@@ -1,0 +1,57 @@
+import {
+  Column,
+  Row,
+  RowData,
+  RowModel,
+  Table,
+  getCoreRowModel,
+  memo,
+} from "@tanstack/react-table";
+
+const getColumnAlignmentProps = (column: Column<any>) => {
+  const align = column.columnDef.meta?.align;
+
+  const className =
+    align === "center"
+      ? "text-center"
+      : align === "right"
+      ? "text-right"
+      : "text-left";
+
+  return { className };
+};
+
+export function getAlignmentRowModel<TData extends RowData>(): (
+  table: Table<TData>
+) => () => RowModel<TData> {
+  return (table) =>
+    memo(
+      () => [table.getFlatHeaders()],
+      (
+        headers
+      ): {
+        rows: Row<TData>[];
+        flatRows: Row<TData>[];
+        rowsById: Record<string, Row<TData>>;
+      } => {
+        const rowModel = getCoreRowModel()(table as Table<unknown>)();
+
+        headers.forEach((header) => {
+          header.getAlignmentProps = () =>
+            getColumnAlignmentProps(header.column);
+        });
+
+        rowModel.rows.forEach((row) => {
+          row.getAllCells().forEach((cell) => {
+            cell.getAlignmentProps = () => getColumnAlignmentProps(cell.column);
+          });
+        });
+
+        return rowModel as RowModel<TData>;
+      },
+      {
+        key: import.meta.env.DEV && "getRowModel",
+        debug: () => table.options.debugAll ?? table.options.debugTable,
+      }
+    );
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,5 @@
+import { HTMLAttributes } from "react";
+
 export * from "./opportunity";
 export type { Opportunity } from "./opportunity";
 
@@ -5,8 +7,11 @@ export const times = <T>(n: number, fn: (i: number) => T) => {
   return Array.from(Array(n)).map((_, i) => fn(i));
 };
 
-export const mergeProps = (...propSets: Record<string, any>[]) => {
+export const mergeProps = (
+  ...propSets: Array<HTMLAttributes<HTMLElement> | undefined>
+) => {
   return propSets.reduce((prev, next) => {
+    if (!next || !prev) return prev;
     return {
       ...prev,
       className: [prev.className, next.className].filter(Boolean).join(" "),


### PR DESCRIPTION
Exploring the limits of custom row model getters

- Would have to pass the custom getter in place of an existing one and call the existing one inside
- It feels awkward to write `getCoreRowModel: getMyCustomRowModel()`, especially for multiple features
- Still using `meta` for custom options. Not all of the table types are extensible, so this is the simplest way
- Fun to work with the built in `memo` helper