### PR TITLE
Create wrapper library

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -15,4 +15,5 @@ module.exports = {
       { allowConstantExport: true },
     ],
   },
+  '@typescript-eslint/no-explicit-any': 0,
 }

--- a/src/components/ExampleTable.tsx
+++ b/src/components/ExampleTable.tsx
@@ -1,27 +1,23 @@
+import { createSpiffColumnHelper, flexRender, useSpiffTable } from "../table";
 import { Opportunity, createOpportunity, times } from "../utils";
-import {
-  createColumnHelper,
-  flexRender,
-  getCoreRowModel,
-  useReactTable,
-} from "@tanstack/react-table";
 
 const data = times(100, createOpportunity);
 
-const columnHelper = createColumnHelper<Opportunity>();
+const columnHelper = createSpiffColumnHelper<Opportunity>();
 
 const columns = [
   columnHelper.accessor("name", {}),
   columnHelper.accessor("accountId", {}),
-  columnHelper.accessor("amount", {}),
-  columnHelper.accessor("aRR", {}),
+  columnHelper.accessor("amount", { align: "right" }),
+  columnHelper.accessor("isClosed", { align: "center" }),
+  columnHelper.accessor("isWon", { align: "center" }),
+  columnHelper.accessor("aRR", { align: "right" }),
 ];
 
 export const ExampleTable = () => {
-  const table = useReactTable({
+  const table = useSpiffTable({
     columns,
     data,
-    getCoreRowModel: getCoreRowModel(),
   });
 
   return (
@@ -29,29 +25,36 @@ export const ExampleTable = () => {
       <thead>
         {table.getHeaderGroups().map((headerGroup) => (
           <tr key={headerGroup.id}>
-            {headerGroup.headers.map((header) => (
-              <th
-                key={header.id}
-                className="border-l-2 p-2"
-                style={{ width: header.getSize() }}
-              >
-                {flexRender(
-                  header.column.columnDef.header,
-                  header.getContext()
-                )}
-              </th>
-            ))}
+            {headerGroup.headers.map((header) => {
+              const spiffHeader = table.prepareHeader(header);
+
+              return (
+                <th key={spiffHeader.id} {...table.getHeaderProps(spiffHeader)}>
+                  {flexRender(
+                    spiffHeader.column.columnDef.header,
+                    spiffHeader.getContext()
+                  )}
+                </th>
+              );
+            })}
           </tr>
         ))}
       </thead>
       <tbody>
         {table.getRowModel().rows.map((row) => (
           <tr key={row.id} className="border-y-2">
-            {row.getVisibleCells().map((cell) => (
-              <td key={cell.id} className="border-l-2 px-2 py-1">
-                {flexRender(cell.column.columnDef.cell, cell.getContext())}
-              </td>
-            ))}
+            {row.getVisibleCells().map((cell) => {
+              const spiffCell = table.prepareCell(cell);
+
+              return (
+                <td key={spiffCell.id} {...table.getCellProps(spiffCell)}>
+                  {flexRender(
+                    spiffCell.column.columnDef.cell,
+                    spiffCell.getContext()
+                  )}
+                </td>
+              );
+            })}
           </tr>
         ))}
       </tbody>

--- a/src/table/features/Alignment.ts
+++ b/src/table/features/Alignment.ts
@@ -1,0 +1,44 @@
+import { RowData } from "@tanstack/react-table";
+import { SpiffColumn, SpiffTableFeature } from "../types";
+import { HTMLAttributes } from "react";
+
+export type AlignmentColumnDef = {
+  align?: "left" | "center" | "right";
+};
+
+type AlignmentPropGetter = () => HTMLAttributes<HTMLElement>;
+
+export interface AlignmentHeader<TData extends RowData, TValue = any> {
+  align?: "left" | "center" | "right";
+  column: SpiffColumn<TData, TValue>;
+  getHeaderProps: AlignmentPropGetter;
+}
+
+const getColumnAlignmentProps = (column: SpiffColumn<any>) => {
+  const align = column.columnDef.align;
+
+  const className =
+    align === "center"
+      ? "text-center"
+      : align === "right"
+      ? "text-right"
+      : "text-left";
+
+  return { className };
+};
+
+export const Alignment: SpiffTableFeature = {
+  getCellProps: (cell) => {
+    const { className } = getColumnAlignmentProps(cell.column);
+    return {
+      className: ["border-l-2", "px-2", "py-1", className].join(" "),
+    };
+  },
+  getHeaderProps: (header) => {
+    const { className } = getColumnAlignmentProps(header.column);
+    return {
+      className: ["border-l-2", "p-2", className].join(" "),
+      style: { width: header.getSize() },
+    };
+  },
+};

--- a/src/table/hooks/useSpiffTable.ts
+++ b/src/table/hooks/useSpiffTable.ts
@@ -54,10 +54,6 @@ const reduceFeature = (
   item: any
 ) => {
   return features.reduce((item, feature) => {
-    if (!(hook in feature)) {
-      return item;
-    }
-
     return feature[hook]?.(item) ?? item;
   }, item);
 };

--- a/src/table/hooks/useSpiffTable.ts
+++ b/src/table/hooks/useSpiffTable.ts
@@ -1,0 +1,63 @@
+import {
+  RowData,
+  createColumnHelper,
+  useReactTable,
+  getCoreRowModel,
+  Table,
+} from "@tanstack/react-table";
+import { Alignment } from "../features/Alignment";
+import {
+  SpiffColumnHelper,
+  SpiffTableOptions,
+  SpiffTable,
+  SpiffTableFeature,
+  SpiffTableHelpers,
+} from "../types";
+
+export const createSpiffColumnHelper = <
+  TData extends RowData
+>(): SpiffColumnHelper<TData> => {
+  return createColumnHelper<TData>() as SpiffColumnHelper<TData>;
+};
+
+export const useSpiffTable = <TData extends RowData>(
+  options: Omit<SpiffTableOptions<TData>, "getCoreRowModel">
+) => {
+  const table = useReactTable({
+    ...options,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  return addSpiffTableFeatures(table);
+};
+
+const addSpiffTableFeatures = <TData extends RowData>(
+  table: Table<TData>
+): SpiffTable<TData> => {
+  // Alignment is a default feature, so don't need to check an `enabled` option
+  const features = [Alignment];
+
+  return {
+    ...table,
+    getCellProps: (cell) => reduceFeature("getCellProps", features, cell),
+    getHeaderProps: (header) =>
+      reduceFeature("getHeaderProps", features, header),
+    prepareCell: (cell) => reduceFeature("prepareCell", features, cell),
+    prepareHeader: (header) => reduceFeature("prepareHeader", features, header),
+    prepareRow: (row) => reduceFeature("prepareRow", features, row),
+  };
+};
+
+const reduceFeature = (
+  hook: keyof SpiffTableHelpers<any>,
+  features: SpiffTableFeature[],
+  item: any
+) => {
+  return features.reduce((item, feature) => {
+    if (!(hook in feature)) {
+      return item;
+    }
+
+    return feature[hook]?.(item) ?? item;
+  }, item);
+};

--- a/src/table/index.ts
+++ b/src/table/index.ts
@@ -1,0 +1,3 @@
+export { createSpiffColumnHelper, useSpiffTable } from "./hooks/useSpiffTable";
+export { flexRender } from "@tanstack/react-table";
+export * from "./types";

--- a/src/table/types.ts
+++ b/src/table/types.ts
@@ -1,0 +1,81 @@
+import {
+  AccessorFn,
+  Cell,
+  Column,
+  ColumnDef,
+  DeepKeys,
+  DeepValue,
+  Header,
+  Row,
+  RowData,
+  Table,
+  TableOptions,
+} from "@tanstack/react-table";
+import { AlignmentColumnDef, AlignmentHeader } from "./features/Alignment";
+import { HTMLAttributes } from "react";
+
+export interface SpiffTableOptions<TData extends RowData>
+  extends TableOptions<TData> {}
+
+export interface SpiffTableHelpers<TData extends RowData> {
+  getCellProps: (
+    cell: SpiffCell<TData, unknown>
+  ) => HTMLAttributes<HTMLElement>;
+  getHeaderProps: (
+    header: SpiffHeader<TData, unknown>
+  ) => HTMLAttributes<HTMLElement>;
+  prepareCell: (cell: Cell<TData, unknown>) => SpiffCell<TData, unknown>;
+  prepareHeader: (
+    header: Header<TData, unknown>
+  ) => SpiffHeader<TData, unknown>;
+  prepareRow: (row: Row<TData>) => SpiffRow<TData>;
+}
+
+export interface SpiffTable<TData extends RowData>
+  extends Table<TData>,
+    SpiffTableHelpers<TData> {}
+
+export type SpiffColumnDef<TData extends RowData, TValue = any> = ColumnDef<
+  TData,
+  TValue
+> &
+  AlignmentColumnDef;
+
+export interface SpiffColumn<TData extends RowData, TValue = any>
+  extends Column<TData, TValue> {
+  columnDef: SpiffColumnDef<TData, TValue>;
+}
+
+type PropGetter = <T>(...args: T[]) => HTMLAttributes<HTMLElement>;
+
+export interface SpiffHeader<TData extends RowData, TValue = any>
+  extends Omit<Header<TData, TValue>, "column">,
+    AlignmentHeader<TData, TValue> {
+  getProps: PropGetter;
+}
+
+export interface SpiffRow<TData extends RowData> extends Row<TData> {}
+
+export interface SpiffCell<TData extends RowData, TValue = any>
+  extends Cell<TData, TValue> {
+  getProps: PropGetter;
+}
+
+export type SpiffColumnHelper<TData extends RowData> = {
+  accessor: <
+    TAccessor extends AccessorFn<TData> | DeepKeys<TData>,
+    TValue extends TAccessor extends AccessorFn<TData, infer TReturn>
+      ? TReturn
+      : TAccessor extends DeepKeys<TData>
+      ? DeepValue<TData, TAccessor>
+      : never
+  >(
+    accessor: TAccessor,
+    column: Partial<SpiffColumnDef<TData, TValue>>
+  ) => SpiffColumnDef<TData, TValue>;
+  // display: (column: SpiffColumnDef<TData>) => SpiffColumnDef<TData, unknown>;
+  // group: (column: SpiffColumnDef<TData>) => SpiffColumnDef<TData, unknown>;
+};
+
+export interface SpiffTableFeature<TData extends RowData = {}>
+  extends Partial<SpiffTableHelpers<TData>> {}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,13 +7,77 @@ export const times = <T>(n: number, fn: (i: number) => T) => {
 
 export const mergeProps = (...propSets: Record<string, any>[]) => {
   return propSets.reduce((prev, next) => {
+    const properties = new Set([...Object.keys(prev), ...Object.keys(next)]);
+    return Array.from(properties).reduce((result, key) => {
+      const prevValue = prev[key];
+      const nextValue = next[key];
+
+      if (
+        typeof prevValue === "function" &&
+        typeof nextValue === "function" &&
+        key.startsWith("on")
+      ) {
+        return {
+          ...result,
+          [key]: mergeCallbacks(prevValue, nextValue),
+        };
+      }
+
+      if (
+        typeof prevValue === "function" &&
+        typeof nextValue === "function" &&
+        key.startsWith("get")
+      ) {
+        return {
+          ...result,
+          [key]: mergePropGetters(prevValue, nextValue),
+        };
+      }
+
+      if (key === "styles") {
+        return {
+          ...result,
+          [key]: mergeStyles(prevValue, nextValue),
+        };
+      }
+
+      if (key === "classNames") {
+        return {
+          ...result,
+          [key]: mergeClassNames(prevValue, nextValue),
+        };
+      }
+
+      return {
+        ...result,
+        [key]: nextValue ?? prevValue,
+      };
+    }, {});
+  }, {});
+};
+
+const mergeClassNames = (...classNames: string[]) =>
+  classNames.filter(Boolean).join(" ");
+
+const mergeStyles = (...styles: React.CSSProperties[]) => {
+  return styles.reduce((prev, next) => {
     return {
       ...prev,
-      className: [prev.className, next.className].filter(Boolean).join(" "),
-      style: {
-        ...prev.style,
-        ...next.style,
-      },
+      ...next,
     };
   }, {});
+};
+
+const mergeCallbacks = (...fns: Function[]) => {
+  return (...args: any[]) => {
+    fns.forEach((fn) => fn(...args));
+  };
+};
+
+const mergePropGetters = (...fns: Function[]) => {
+  return (...args: any[]) => {
+    return fns.reduce((prev, next) => {
+      return mergeProps(prev, next(...args));
+    }, {});
+  };
 };


### PR DESCRIPTION
Some of the important types from tanstack are `Types` and not `Interfaces` and can't be extended. This PR imagines what it might be like if the tanstack library were just an implementation detail, wrapped and obscured by our own types and code.

- Custom types means the API can be whatever we want, for better or worse
- Can opt to resemble v7 more closely
- Don't need to use `meta`, at least in the public API. Might want to internally
- Custom types will get confusing, probably brittle. Might need to disallow importing from the lib itself